### PR TITLE
Refine radio set-frequency schema: frequency_khz str → float

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ CI runs automatically via GitHub Actions on pushes to `main` and PRs when `backe
 | PUT | `/api/settings` | Update operator callsign, flrig host/port |
 | GET | `/api/parks/{park_ref}` | Proxy to POTA park API (returns park name/location) |
 | GET | `/api/spots` | Proxy to POTA activator spots API; optional `band` and `mode` query params for server-side filtering; each spot includes `hunted` flag based on today's QSOs |
-| POST | `/api/radio/set-frequency` | Set radio frequency via flrig XML-RPC; body: `{ frequency_khz: string }`; returns 503 if flrig unreachable |
+| POST | `/api/radio/set-frequency` | Set radio frequency via flrig XML-RPC; body: `{ frequency_khz: number }`; returns 503 if flrig unreachable |
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Tests use in-memory SQLite — no running database required. External POTA API c
 | PUT | `/api/settings` | Update operator callsign, flrig host/port |
 | GET | `/api/parks/{park_ref}` | Park name/location lookup |
 | GET | `/api/spots` | Active POTA activator spots (optional `band`, `mode` query params); includes `hunted` flag |
-| POST | `/api/radio/set-frequency` | Set radio frequency via flrig XML-RPC; body: `{ frequency_khz: string }` |
+| POST | `/api/radio/set-frequency` | Set radio frequency via flrig XML-RPC; body: `{ frequency_khz: number }` |

--- a/backend/app/routers/radio.py
+++ b/backend/app/routers/radio.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/api/radio", tags=["radio"])
 
 
 class SetFrequencyRequest(BaseModel):
-    frequency_khz: str
+    frequency_khz: float
 
 
 @router.post("/set-frequency")
@@ -23,7 +23,7 @@ async def set_frequency(data: SetFrequencyRequest, db: AsyncSession = Depends(ge
     host = settings.flrig_host if settings else "localhost"
     port = settings.flrig_port if settings else 12345
 
-    freq_hz = float(data.frequency_khz) * 1000
+    freq_hz = data.frequency_khz * 1000
 
     def call_flrig():
         proxy = xmlrpc.client.ServerProxy(f"http://{host}:{port}")


### PR DESCRIPTION
## Summary

- Change `SetFrequencyRequest.frequency_khz` from `str` to `float` — Pydantic coerces JSON string or number inputs automatically, removing the need for an explicit `float()` cast in the endpoint
- Simplify `freq_hz = data.frequency_khz * 1000` (was `float(data.frequency_khz) * 1000`)
- Update `CLAUDE.md` and `README.md` API docs to reflect `frequency_khz: number`

## Test plan

- [x] `cd backend && . .venv/bin/activate && python -m pytest tests/test_radio.py -v` — all 6 tests pass (frontend still sends string `"14074.0"`, Pydantic coerces it correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)